### PR TITLE
feat: switching "date" header to "x-metronome-date" header

### DIFF
--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -82,7 +82,7 @@ export class Webhooks extends APIResource {
   ): void {
     this.validateSecret(secret);
 
-    const msgDate = getRequiredHeader(headers, 'Date');
+    const msgDate = getRequiredHeader(headers, 'X-Metronome-Date');
     const msgSignature = getRequiredHeader(headers, 'Metronome-Webhook-Signature');
 
     const now = Date.now();

--- a/tests/api-resources/webhooks.test.ts
+++ b/tests/api-resources/webhooks.test.ts
@@ -20,7 +20,7 @@ describe('resource webhooks', () => {
   const signature = 'b82652fa2246cf1d8a27e591f155c865f68b46c19b9213fd9c052f2419b4742b';
   const date = 'Mon, 02 Jan 2006 22:04:05 GMT';
   const headers = {
-    Date: date,
+    'X-Metronome-Date': date,
     'Metronome-Webhook-Signature': signature,
   };
   const secret = 'correct-horse-battery-staple';
@@ -85,7 +85,7 @@ describe('resource webhooks', () => {
         payload,
         {
           ...headers,
-          Date: 'nan',
+          'X-Metronome-Date': 'nan',
         },
         secret,
       ),


### PR DESCRIPTION
Date header was getting overridden by middleware, so switching to using x-metronome-date