### PR TITLE
docs(mcp-server): mark package as deprecated

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,5 +1,7 @@
 # Metronome TypeScript MCP Server
 
+> **Deprecated:** This MCP server is no longer actively maintained and will not receive further updates. The npm package has also been [marked as deprecated](https://www.npmjs.com/package/@metronome/mcp).
+
 It is generated with [Stainless](https://www.stainless.com/).
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add README with a deprecation notice
- Links to the npm package page which is already marked as deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)